### PR TITLE
Create initial structure for websocket client

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ is going to provide you a shell with your environment (and build a docker image 
 We suggest using docker for development.
 
 ## Usage
-Examples for how to use clients defined in the projects can be found inside: `examples.py`
+Examples for how to use clients defined in the projects can be found inside: `examples.py` and `examples_ws.py`

--- a/examples_ws.py
+++ b/examples_ws.py
@@ -1,0 +1,11 @@
+import ws
+
+def msg_received_callback(message):
+    """
+    Example callback that is passed to WS client for receiving messages.
+    """
+    print(message)
+
+print('[*] Running example WS Client')
+c = ws.WebsocketV2Client(channels=['live_trades_xrpusd', 'live_trades_xrpeur'], callback=msg_received_callback)
+c.run()

--- a/ws/__init__.py
+++ b/ws/__init__.py
@@ -1,0 +1,5 @@
+from .client import WebsocketV2Client
+
+__all__ = [
+    'WebsocketV2Client'
+]

--- a/ws/client.py
+++ b/ws/client.py
@@ -1,0 +1,66 @@
+import websocket
+import json
+import threading
+import typing
+
+
+class WebsocketV2Client(threading.Thread):
+    _worker: websocket.WebSocketApp
+    _channels: typing.List[str]
+
+    _WS_ENDPOINT = 'wss://ws.bitstamp.net/'
+
+    def __init__(self, channels: typing.List[str], callback=None):
+        super().__init__()
+        self._channels = channels
+        self._worker = websocket.WebSocketApp(self._WS_ENDPOINT,
+                                              on_open=self.on_open,
+                                              on_message=self.on_message,
+                                              on_error=self.on_error,
+                                              on_close=self.on_close)
+
+        self._msg_received_callback = callback
+
+    def run(self):
+        self._worker.run_forever()
+
+    def subscribe_to_channel(self, channel: str):
+        subscribe_msg = {
+            'event': 'bts:subscribe',
+            'data': {
+                'channel': '{0}'.format(channel)
+            }
+        }
+        json_msg = json.dumps(subscribe_msg)
+        self._worker.send(json_msg)
+
+    def unsubscribe_from_channel(self, channel: str):
+        unsubscribe_msg = {
+            'event': 'bts:unsubscribe',
+            'data': {
+                'channel': '{0}'.format(channel)
+            }
+        }
+
+        json_msg = json.dumps(unsubscribe_msg)
+        self._worker.send(json_msg)
+
+    def on_message(self, ws, message):
+        """
+        Interface method that determines what happens on recevied message
+        """
+        if self._msg_received_callback:
+            self._msg_received_callback(message)
+
+    def on_error(self, ws, error):
+        """
+        Interface method that determines what happens on error
+        """
+        print(error)
+
+    def on_close(self, ws, close_status_code, close_msg):
+        print('Connection closed')
+
+    def on_open(self, ws):
+        for channel in self._channels:
+            self.subscribe_to_channel(channel)


### PR DESCRIPTION
This would create initial structure for websocket client. One needs to create a client, specify which channels to connect to, and then run it. (We'll probably run it in separate thread once actually using it).

I added `examples_ws.py` so you can run `python examples_ws.py` in order to test it. once you run it, wait for couple of second, and stream of real-time trade data should start to come in.

As you can see, one can pass custom callback for message received to client, in order to handle incoming messages.